### PR TITLE
Bump Hadoop to 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.targetJdk>1.7</project.build.targetJdk>
         <shadeBase>com.facebook.presto.hadoop.shaded</shadeBase>
-        <dep.slf4j.version>1.7.5</dep.slf4j.version>
+        <dep.slf4j.version>1.7.10</dep.slf4j.version>
         <dep.hadoop.version>2.7.1</dep.hadoop.version>
     </properties>
 
@@ -429,6 +429,10 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
                             <relocations>
+				<relocation>
+				    <pattern>org.iq80.leveldb</pattern>
+				    <shadedPattern>${shadeBase}.org.iq80.leveldb</shadedPattern>
+				</relocation>
 				<relocation>
 				    <pattern>org.apache.http</pattern>
 				    <shadedPattern>${shadeBase}.org.apache.http</shadedPattern>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.facebook.presto.hadoop</groupId>
     <artifactId>hadoop-apache2</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3-SNAPSHOT</version>
 
     <name>hadoop-apache2</name>
     <description>Shaded version of Apache Hadoop 2.x for Presto</description>
@@ -42,7 +42,7 @@
         <project.build.targetJdk>1.7</project.build.targetJdk>
         <shadeBase>com.facebook.presto.hadoop.shaded</shadeBase>
         <dep.slf4j.version>1.7.5</dep.slf4j.version>
-        <dep.hadoop.version>2.2.0</dep.hadoop.version>
+        <dep.hadoop.version>2.7.1</dep.hadoop.version>
     </properties>
 
     <dependencies>
@@ -79,6 +79,10 @@
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-math</artifactId>
                 </exclusion>
+		<exclusion>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-math3</artifactId>
+		</exclusion>
                 <exclusion>
                     <groupId>commons-beanutils</groupId>
                     <artifactId>commons-beanutils</artifactId>
@@ -86,10 +90,6 @@
                 <exclusion>
                     <groupId>commons-beanutils</groupId>
                     <artifactId>commons-beanutils-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>commons-digester</groupId>
@@ -190,7 +190,7 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${dep.hadoop.version}</version>
-            <scope>runtime</scope>
+            <!--scope>runtime</scope-->
             <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>
@@ -259,7 +259,7 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${dep.hadoop.version}</version>
-            <scope>runtime</scope>
+            <!--scope>runtime</scope-->
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
@@ -429,6 +429,14 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
                             <relocations>
+				<relocation>
+				    <pattern>org.apache.http</pattern>
+				    <shadedPattern>${shadeBase}.org.apache.http</shadedPattern>
+				</relocation>
+				<relocation>
+				   <pattern>org.jboss.netty</pattern>
+				   <shadedPattern>${shadeBase}.org.jboss.netty</shadedPattern>
+			 	</relocation>
                                 <relocation>
                                     <pattern>org.apache.avro</pattern>
                                     <shadedPattern>${shadeBase}.org.apache.avro</shadedPattern>


### PR DESCRIPTION
Bumping Hadoop Dependency to 2.7.1 which includes multiple RecordReader fixes for Hive.