### PR TITLE
Fixed Hadoop 2.7.1 Dependencies for S3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,12 +222,6 @@
            </exclusions>
         </dependency>
 
-        <!--dependency>
-            <groupId>javax.xml</groupId>
-            <artifactId>jaxp-api</artifactId>
-            <version>1.4.2</version>
-        </dependency-->
-
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.1</version>
+            <version>2.2.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,30 @@
             </exclusions>
         </dependency>
 
+	<dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-aws</artifactId>
+            <version>${dep.hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                   <groupId>com.amazonaws</groupId>
+                   <artifactId>aws-java-sdk</artifactId>
+                </exclusion>
+           </exclusions>
+        </dependency>
+
+        <!--dependency>
+            <groupId>javax.xml</groupId>
+            <artifactId>jaxp-api</artifactId>
+            <version>1.4.2</version>
+        </dependency-->
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
@@ -463,6 +487,14 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
                             <relocations>
+				<relocation>
+                                    <pattern>org.joda.time</pattern>
+                                    <shadedPattern>${shadeBase}.org.joda.time</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>${shadeBase}.com.fasterxml</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>org.iq80.leveldb</pattern>
                                     <shadedPattern>${shadeBase}.org.iq80.leveldb</shadedPattern>

--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,28 @@
             <version>6.2.1</version>
             <scope>test</scope>
         </dependency>
+
+	<dependency>
+	   <groupId>com.amazonaws</groupId>
+	   <artifactId>aws-java-sdk</artifactId>
+	   <version>1.8.9.1</version>
+	   <scope>test</scope>
+	   <exclusions>
+		<exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+		<exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+	        <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>	
+	   </exclusions>
+	</dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Added hadoop-aws package to satisfy dependencies for querying data in S3. 
Successful tests now include S3 and HDFS bzip2 data being queried from Presto 0.128

### Tests

#### S3 Based Query 
```
presto:default> select col1, col2, col3, col57 from s3_bz2_table where mydate = cast('2015-06-01' as date) limit 10;
    col1    |    col2    |   col3   |  col57   
------------+------------+----------+----------
 row_926749 | 2015-06-01 | 56993665 | 9310.345 
 row_926750 | 2015-06-01 | 56993665 | 479.398  
 row_926751 | 2015-06-01 | 56993665 | 2106.145 
 row_926752 | 2015-06-01 | 56993665 | 873.714  
 row_926753 | 2015-06-01 | 56993665 | 127.1049 
 row_926754 | 2015-06-01 | 56993665 | 6610.957 
 row_926755 | 2015-06-01 | 56993665 | 771.794  
 row_926756 | 2015-06-01 | 56993665 | 939.725  
 row_926757 | 2015-06-01 | 56993665 | 387.686  
 row_926758 | 2015-06-01 | 56993665 | 541.6710 
(10 rows)

Query 20151210_124803_00016_6n8gx, FINISHED, 2 nodes
Splits: 191 total, 20 done (10.47%)
0:10 [70.5K rows, 10.7MB] [6.78K rows/s, 1.03MB/s]
```

#### HDFS Test Query
```
presto:default> select col1, col2, col3, col57 from hdfs_bz2_table where mydate = cast('2015-06-01' as date) limit 10;
    col1     |    col2    |   col3   |  col57   
-------------+------------+----------+----------
 row_3243936 | 2015-06-01 | 56993665 | 439.915  
 row_3243937 | 2015-06-01 | 56993665 | 196.372  
 row_3243938 | 2015-06-01 | 56993665 | 671.254  
 row_3243939 | 2015-06-01 | 56993665 | 1067.518 
 row_3243940 | 2015-06-01 | 56993665 | 351.992  
 row_3243941 | 2015-06-01 | 56993665 | 819.286  
 row_3243942 | 2015-06-01 | 56993665 | 966.288  
 row_3243943 | 2015-06-01 | 56993665 | 552.238  
 row_3243944 | 2015-06-01 | 56993665 | 568.995  
 row_3243945 | 2015-06-01 | 56993665 | 449.164  
(10 rows)

Query 20151210_125820_00002_8ejfu, FINISHED, 2 nodes
Splits: 191 total, 2 done (1.05%)
0:09 [28.7K rows, 4.39MB] [3.08K rows/s, 484KB/s]
```