### PR TITLE
Remove shading for apache httpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,6 @@
                     <artifactId>apacheds-kerberos-codec</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
                 </exclusion>


### PR DESCRIPTION
This fix the following problem:

When using Hadoop KMS, presto select and insert fails:
```
java.lang.NoClassDefFoundError: com/facebook/presto/hadoop/$internal/org/apache/http/client/utils/URIBuilder
	at org.apache.hadoop.crypto.key.kms.KMSClientProvider.createURL(KMSClientProvider.java:433)
	at org.apache.hadoop.crypto.key.kms.KMSClientProvider.decryptEncryptedKey(KMSClientProvider.java:773)
	at org.apache.hadoop.crypto.key.KeyProviderCryptoExtension.decryptEncryptedKey(KeyProviderCryptoExtension.java:388)
	at org.apache.hadoop.hdfs.DFSClient.decryptEncryptedDataEncryptionKey(DFSClient.java:1395)
	at org.apache.hadoop.hdfs.DFSClient.createWrappedOutputStream(DFSClient.java:1497)
	at org.apache.hadoop.hdfs.DFSClient.createWrappedOutputStream(DFSClient.java:1482)
	at org.apache.hadoop.hdfs.DistributedFileSystem$7.doCall(DistributedFileSystem.java:451)
	at org.apache.hadoop.hdfs.DistributedFileSystem$7.doCall(DistributedFileSystem.java:444)
	at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81)
	at org.apache.hadoop.hdfs.DistributedFileSystem.create(DistributedFileSystem.java:459)
	at org.apache.hadoop.hdfs.DistributedFileSystem.create(DistributedFileSystem.java:387)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:909)
	at org.apache.hadoop.fs.FileSystem.create(FileSystem.java:802)
	at org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat.getHiveRecordWriter(HiveIgnoreKeyTextOutputFormat.java:80)
	at com.facebook.presto.hive.HiveWriteUtils.createRecordWriter(HiveWriteUtils.java:101)
	at com.facebook.presto.hive.HivePageSink$HiveRecordWriter.<init>(HivePageSink.java:538)
	at com.facebook.presto.hive.HivePageSink.createWriter(HivePageSink.java:396)
	at com.facebook.presto.hive.HivePageSink.appendPage(HivePageSink.java:272)
	at com.facebook.presto.hive.auth.HdfsAuthenticatingPageSink.lambda$appendPage$31(HdfsAuthenticatingPageSink.java:42)
	at com.facebook.presto.hive.auth.HdfsAuthenticatingPageSink$$Lambda$431/210091024.run(Unknown Source)
	at com.facebook.presto.hive.auth.HadoopAuthentication.lambda$doAs$2(HadoopAuthentication.java:54)
	at com.facebook.presto.hive.auth.HadoopAuthentication$$Lambda$428/1763281406.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:360)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1637)
	at com.facebook.presto.hive.auth.HadoopAuthentication.doAs(HadoopAuthentication.java:53)
	at com.facebook.presto.hive.auth.HdfsAuthenticatingPageSink.appendPage(HdfsAuthenticatingPageSink.java:42)
	at com.facebook.presto.spi.classloader.ClassLoaderSafeConnectorPageSink.appendPage(ClassLoaderSafeConnectorPageSink.java:41)
	at com.facebook.presto.operator.TableWriterOperator.addInput(TableWriterOperator.java:182)
	at com.facebook.presto.operator.Driver.processInternal(Driver.java:386)
	at com.facebook.presto.operator.Driver.processFor(Driver.java:303)
	at com.facebook.presto.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:573)
	at com.facebook.presto.execution.TaskExecutor$PrioritizedSplitRunner.process(TaskExecutor.java:505)
	at com.facebook.presto.execution.TaskExecutor$Runner.run(TaskExecutor.java:640)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ClassNotFoundException: com.facebook.presto.hadoop.$internal.org.apache.http.client.utils.URIBuilder
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at com.facebook.presto.server.PluginClassLoader.loadClass(PluginClassLoader.java:102)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 37 more
```