### PR TITLE
Include hadoop-azure in the shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,36 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-azure</artifactId>
+            <version>${dep.hadoop.version}</version>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.microsoft.azure</groupId>
+                    <artifactId>azure-storage</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+
         <!-- discard all logging from hadoop -->
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Add the hadoop-azure to the shaded version of Apache Hadoop 2.x. The [hadoop-azure](http://hadoop.apache.org/docs/current/hadoop-azure/index.html) contains an implementation of Hadoop FileSystem interface on top of Azure Blob Storage. My main use case is to use Presto to query data in Azure Blob Storage similar to the S3 support in Presto. The hadoop-azure is part of Apache Hadoop project, so I think it fits into the shaded Apache Hadoop jar here.
