### PR TITLE
Include Hadoop KMS dependencies in shaded jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,16 @@
             <artifactId>httpclient</artifactId>
             <version>${dep.httpclient.version}</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- discard all logging from hadoop -->

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <shadeBase>com.facebook.presto.hadoop.\$internal</shadeBase>
         <dep.slf4j.version>1.7.13</dep.slf4j.version>
         <dep.hadoop.version>2.7.3</dep.hadoop.version>
+        <dep.httpclient.version>4.5.2</dep.httpclient.version>
     </properties>
 
     <dependencies>
@@ -118,14 +119,6 @@
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-core-asl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.sun.jersey</groupId>
@@ -229,14 +222,6 @@
                     <artifactId>leveldbjni-all</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-core-asl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-core</artifactId>
                 </exclusion>
@@ -310,6 +295,13 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${dep.httpclient.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- discard all logging from hadoop -->


### PR DESCRIPTION
When Hadoop KMS is used, Presto Hive plugin calls org.apache.hadoop.crypto.key.kms.KMSClientProvider.createURL which fails with the current master.

Hadoop KMS calls use URIBuilder class which is missing in shaded version of hadoop libraries.

This change includes:
1) httpclient library which contains URIBuilder class,
2) jackson-core-asl and jackson-mapper-asl libraries (hadoop kms code uses jackson json parser)

Issue: https://github.com/prestodb/presto-hadoop-apache2/issues/15