### PR TITLE
Hold FileSystem reference in a returned stream

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
+++ b/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
@@ -17,12 +17,15 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
+import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -105,7 +108,7 @@ public final class PrestoFileSystemCache
         }
         final FileSystem original = (FileSystem) ReflectionUtils.newInstance(clazz, conf);
         original.initialize(uri, conf);
-        FilterFileSystem wrapper = new FilterFileSystem(original);
+        FilterFileSystem wrapper = new FileSystemWrapper(original);
         FinalizerService.getInstance().addFinalizer(wrapper, new Runnable()
         {
             @Override
@@ -280,6 +283,75 @@ public final class PrestoFileSystemCache
                     .add("fileSystem", fileSystem)
                     .add("privateCredentials", privateCredentials)
                     .toString();
+        }
+    }
+
+    private static class FileSystemWrapper
+            extends FilterFileSystem
+    {
+        public FileSystemWrapper(FileSystem fs)
+        {
+            super(fs);
+        }
+
+        @Override
+        public FSDataInputStream open(Path f, int bufferSize)
+                throws IOException
+        {
+            return new InputStreamWrapper(getRawFileSystem().open(f, bufferSize), this);
+        }
+
+        @Override
+        public FSDataOutputStream append(Path f, int bufferSize, Progressable progress)
+                throws IOException
+        {
+            return new OutputStreamWrapper(getRawFileSystem().append(f, bufferSize, progress), this);
+        }
+
+        @Override
+        public FSDataOutputStream create(Path f, FsPermission permission, boolean overwrite, int bufferSize, short replication, long blockSize, Progressable progress)
+                throws IOException
+        {
+            return new OutputStreamWrapper(getRawFileSystem().create(f, permission, overwrite, bufferSize, replication, blockSize, progress), this);
+        }
+
+        @Override
+        public FSDataOutputStream create(Path f, FsPermission permission, EnumSet<CreateFlag> flags, int bufferSize, short replication, long blockSize, Progressable progress, Options.ChecksumOpt checksumOpt)
+                throws IOException
+        {
+            return new OutputStreamWrapper(getRawFileSystem().create(f, permission, flags, bufferSize, replication, blockSize, progress, checksumOpt), this);
+        }
+
+        @Override
+        public FSDataOutputStream createNonRecursive(Path f, FsPermission permission, EnumSet<CreateFlag> flags, int bufferSize, short replication, long blockSize, Progressable progress)
+                throws IOException
+        {
+            return new OutputStreamWrapper(getRawFileSystem().createNonRecursive(f, permission, flags, bufferSize, replication, blockSize, progress), this);
+        }
+    }
+
+    private static class OutputStreamWrapper
+            extends FSDataOutputStream
+    {
+        private final FileSystem fileSystem;
+
+        public OutputStreamWrapper(FSDataOutputStream delegate, FileSystem fileSystem)
+                throws IOException
+        {
+            super(delegate, null, delegate.getPos());
+            this.fileSystem = fileSystem;
+        }
+    }
+
+    private static class InputStreamWrapper
+            extends FSDataInputStream
+    {
+        private final FileSystem fileSystem;
+
+        public InputStreamWrapper(FSDataInputStream inputStream, FileSystem fileSystem)
+        {
+            super(inputStream);
+            this.fileSystem = fileSystem;
         }
     }
 }

--- a/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
+++ b/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
@@ -89,7 +89,7 @@ public final class PrestoFileSystemCache
         // a part of the FileSystemKey, but part of the FileSystemHolder. When a
         // Kerberos re-login occurs, re-create the file system and cache it using
         // the same key.
-        if (!fileSystemHolder.getPrivateCredentials().equals(privateCredentials)) {
+        if (isHdfs(uri) && !fileSystemHolder.getPrivateCredentials().equals(privateCredentials)) {
             map.remove(key);
             FileSystem fileSystem = createFileSystem(uri, conf);
             fileSystemHolder = new FileSystemHolder(fileSystem, privateCredentials);
@@ -200,6 +200,11 @@ public final class PrestoFileSystemCache
             default:
                 throw new IllegalArgumentException("Unsupported authentication method: " + authenticationMethod);
         }
+    }
+
+    private static boolean isHdfs(URI uri)
+    {
+        return "hdfs".equals(uri.getScheme());
     }
 
     private static class FileSystemKey


### PR DESCRIPTION
This is supposed to prevent premature file system finalization