### PR TITLE
Add viewfs when check hdfs scheme

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
+++ b/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
@@ -204,7 +204,8 @@ public final class PrestoFileSystemCache
 
     private static boolean isHdfs(URI uri)
     {
-        return "hdfs".equals(uri.getScheme());
+        String scheme = uri.getScheme();
+        return "hdfs".equals(scheme) || "viewfs".equals(scheme);
     }
 
     private static class FileSystemKey


### PR DESCRIPTION
This fix the problem on during checking whether need to invalidate the cached FileSystemHolder, it need to include scheme "viewfs" which is also commonly used by hdfs.