### PR TITLE
Line reader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,24 +368,6 @@
 
             <plugin>
                 <groupId>com.ning.maven.plugins</groupId>
-                <artifactId>maven-duplicate-finder-plugin</artifactId>
-                <version>1.0.4</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>com.ning.maven.plugins</groupId>
                 <artifactId>maven-dependency-versions-check-plugin</artifactId>
                 <version>2.0.2</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -542,6 +542,7 @@
                                     <artifact>org.apache.hadoop:hadoop-common</artifact>
                                     <excludes>
                                         <exclude>*.h</exclude>
+                                        <exclude>org/apache/hadoop/util/LineReader.class</exclude>
                                     </excludes>
                                 </filter>
                                 <filter>

--- a/src/main/java/org/apache/hadoop/util/LineReader.java
+++ b/src/main/java/org/apache/hadoop/util/LineReader.java
@@ -1,0 +1,420 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.util;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A class that provides a line reader from an input stream.
+ * Depending on the constructor used, lines will either be terminated by:
+ * <ul>
+ * <li>one of the following: '\n' (LF) , '\r' (CR),
+ * or '\r\n' (CR+LF).</li>
+ * <li><em>or</em>, a custom byte sequence delimiter</li>
+ * </ul>
+ * In both cases, EOF also terminates an otherwise unterminated
+ * line.
+ */
+@InterfaceAudience.LimitedPrivate({"MapReduce"})
+@InterfaceStability.Unstable
+public class LineReader
+        implements Closeable
+{
+    private static final int DEFAULT_BUFFER_SIZE = 64 * 1024;
+    private static final byte CR = '\r';
+    private static final byte LF = '\n';
+    // The line delimiter
+    private final byte[] recordDelimiterBytes;
+    private int bufferSize = DEFAULT_BUFFER_SIZE;
+    private InputStream in;
+    private byte[] buffer;
+    // the number of bytes of real data in the buffer
+    private int bufferLength = 0;
+    // the current position in the buffer
+    private int bufferPosn = 0;
+
+    /**
+     * Create a line reader that reads from the given stream using the
+     * default buffer-size (64k).
+     * @param in The input stream
+     * @throws IOException
+     */
+    public LineReader(InputStream in)
+    {
+        this(in, DEFAULT_BUFFER_SIZE);
+    }
+
+    /**
+     * Create a line reader that reads from the given stream using the
+     * given buffer-size.
+     * @param in The input stream
+     * @param bufferSize Size of the read buffer
+     * @throws IOException
+     */
+    public LineReader(InputStream in, int bufferSize)
+    {
+        this.in = in;
+        this.bufferSize = bufferSize;
+        this.buffer = new byte[this.bufferSize];
+        this.recordDelimiterBytes = null;
+    }
+
+    /**
+     * Create a line reader that reads from the given stream using the
+     * <code>io.file.buffer.size</code> specified in the given
+     * <code>Configuration</code>.
+     * @param in input stream
+     * @param conf configuration
+     * @throws IOException
+     */
+    public LineReader(InputStream in, Configuration conf)
+            throws IOException
+    {
+        this(in, conf.getInt("io.file.buffer.size", DEFAULT_BUFFER_SIZE));
+    }
+
+    /**
+     * Create a line reader that reads from the given stream using the
+     * default buffer-size, and using a custom delimiter of array of
+     * bytes.
+     * @param in The input stream
+     * @param recordDelimiterBytes The delimiter
+     */
+    public LineReader(InputStream in, byte[] recordDelimiterBytes)
+    {
+        this.in = in;
+        this.bufferSize = DEFAULT_BUFFER_SIZE;
+        this.buffer = new byte[this.bufferSize];
+        this.recordDelimiterBytes = recordDelimiterBytes;
+    }
+
+    /**
+     * Create a line reader that reads from the given stream using the
+     * given buffer-size, and using a custom delimiter of array of
+     * bytes.
+     * @param in The input stream
+     * @param bufferSize Size of the read buffer
+     * @param recordDelimiterBytes The delimiter
+     * @throws IOException
+     */
+    public LineReader(InputStream in, int bufferSize,
+            byte[] recordDelimiterBytes)
+    {
+        this.in = in;
+        this.bufferSize = bufferSize;
+        this.buffer = new byte[this.bufferSize];
+        this.recordDelimiterBytes = recordDelimiterBytes;
+    }
+
+    /**
+     * Create a line reader that reads from the given stream using the
+     * <code>io.file.buffer.size</code> specified in the given
+     * <code>Configuration</code>, and using a custom delimiter of array of
+     * bytes.
+     * @param in input stream
+     * @param conf configuration
+     * @param recordDelimiterBytes The delimiter
+     * @throws IOException
+     */
+    public LineReader(InputStream in, Configuration conf,
+            byte[] recordDelimiterBytes)
+            throws IOException
+    {
+        this.in = in;
+        this.bufferSize = conf.getInt("io.file.buffer.size", DEFAULT_BUFFER_SIZE);
+        this.buffer = new byte[this.bufferSize];
+        this.recordDelimiterBytes = recordDelimiterBytes;
+    }
+
+    /**
+     * Close the underlying stream.
+     * @throws IOException
+     */
+    public void close()
+            throws IOException
+    {
+        in.close();
+    }
+
+    /**
+     * Read one line from the InputStream into the given Text.
+     *
+     * @param str the object to store the given line (without newline)
+     * @param maxLineLength the maximum number of bytes to store into str;
+     *  the rest of the line is silently discarded.
+     * @param maxBytesToConsume the maximum number of bytes to consume
+     *  in this call.  This is only a hint, because if the line cross
+     *  this threshold, we allow it to happen.  It can overshoot
+     *  potentially by as much as one buffer length.
+     *
+     * @return the number of bytes read including the (longest) newline
+     * found.
+     *
+     * @throws IOException if the underlying stream throws
+     */
+    public int readLine(Text str, int maxLineLength,
+            int maxBytesToConsume)
+            throws IOException
+    {
+        if (this.recordDelimiterBytes != null) {
+            return readCustomLine(str, maxLineLength, maxBytesToConsume);
+        }
+        else {
+            return readDefaultLine(str, maxLineLength, maxBytesToConsume);
+        }
+    }
+
+    protected int fillBuffer(InputStream in, byte[] buffer, boolean inDelimiter)
+            throws IOException
+    {
+        return in.read(buffer);
+    }
+
+    /**
+     * Read a line terminated by one of CR, LF, or CRLF.
+     */
+    private int readDefaultLine(Text str, int maxLineLength, int maxBytesToConsume)
+            throws IOException
+    {
+        /* We're reading data from in, but the head of the stream may be
+         * already buffered in buffer, so we have several cases:
+         * 1. No newline characters are in the buffer, so we need to copy
+         *    everything and read another buffer from the stream.
+         * 2. An unambiguously terminated line is in buffer, so we just
+         *    copy to str.
+         * 3. Ambiguously terminated line is in buffer, i.e. buffer ends
+         *    in CR.  In this case we copy everything up to CR to str, but
+         *    we also need to see what follows CR: if it's LF, then we
+         *    need consume LF as well, so next call to readLine will read
+         *    from after that.
+         * We use a flag prevCharCR to signal if previous character was CR
+         * and, if it happens to be at the end of the buffer, delay
+         * consuming it until we have a chance to look at the char that
+         * follows.
+         */
+        str.clear();
+        int txtLength = 0; //tracks str.getLength(), as an optimization
+        int newlineLength = 0; //length of terminating newline
+        boolean prevCharCR = false; //true of prev char was CR
+        long bytesConsumed = 0;
+        do {
+            int startPosn = bufferPosn; //starting from where we left off the last time
+            if (bufferPosn >= bufferLength) {
+                startPosn = bufferPosn = 0;
+                if (prevCharCR) {
+                    ++bytesConsumed; //account for CR from previous read
+                }
+                bufferLength = fillBuffer(in, buffer, prevCharCR);
+                if (bufferLength <= 0) {
+                    break; // EOF
+                }
+            }
+            for (; bufferPosn < bufferLength; ++bufferPosn) { //search for newline
+                if (buffer[bufferPosn] == LF) {
+                    newlineLength = (prevCharCR) ? 2 : 1;
+                    ++bufferPosn; // at next invocation proceed from following byte
+                    break;
+                }
+                if (prevCharCR) { //CR + notLF, we are at notLF
+                    newlineLength = 1;
+                    break;
+                }
+                prevCharCR = (buffer[bufferPosn] == CR);
+            }
+            int readLength = bufferPosn - startPosn;
+            if (prevCharCR && newlineLength == 0) {
+                --readLength; //CR at the end of the buffer
+            }
+            bytesConsumed += readLength;
+            int appendLength = readLength - newlineLength;
+            if (appendLength > maxLineLength - txtLength) {
+                appendLength = maxLineLength - txtLength;
+            }
+            if (appendLength > 0) {
+                str.append(buffer, startPosn, appendLength);
+                txtLength += appendLength;
+            }
+        }
+        while (newlineLength == 0 && bytesConsumed < maxBytesToConsume);
+
+        if (bytesConsumed > Integer.MAX_VALUE) {
+            throw new IOException("Too many bytes before newline: " + bytesConsumed);
+        }
+        return (int) bytesConsumed;
+    }
+
+    /**
+     * Read a line terminated by a custom delimiter.
+     */
+    private int readCustomLine(Text str, int maxLineLength, int maxBytesToConsume)
+            throws IOException
+    {
+        /* We're reading data from inputStream, but the head of the stream may be
+         *  already captured in the previous buffer, so we have several cases:
+         *
+         * 1. The buffer tail does not contain any character sequence which
+         *    matches with the head of delimiter. We count it as a
+         *    ambiguous byte count = 0
+         *
+         * 2. The buffer tail contains a X number of characters,
+         *    that forms a sequence, which matches with the
+         *    head of delimiter. We count ambiguous byte count = X
+         *
+         *    // ***  eg: A segment of input file is as follows
+         *
+         *    " record 1792: I found this bug very interesting and
+         *     I have completely read about it. record 1793: This bug
+         *     can be solved easily record 1794: This ."
+         *
+         *    delimiter = "record";
+         *
+         *    supposing:- String at the end of buffer =
+         *    "I found this bug very interesting and I have completely re"
+         *    There for next buffer = "ad about it. record 179       ...."
+         *
+         *     The matching characters in the input
+         *     buffer tail and delimiter head = "re"
+         *     Therefore, ambiguous byte count = 2 ****   //
+         *
+         *     2.1 If the following bytes are the remaining characters of
+         *         the delimiter, then we have to capture only up to the starting
+         *         position of delimiter. That means, we need not include the
+         *         ambiguous characters in str.
+         *
+         *     2.2 If the following bytes are not the remaining characters of
+         *         the delimiter ( as mentioned in the example ),
+         *         then we have to include the ambiguous characters in str.
+         */
+        str.clear();
+        int txtLength = 0; // tracks str.getLength(), as an optimization
+        long bytesConsumed = 0;
+        int delPosn = 0;
+        int ambiguousByteCount = 0; // To capture the ambiguous characters count
+        do {
+            int startPosn = bufferPosn; // Start from previous end position
+            if (bufferPosn >= bufferLength) {
+                startPosn = bufferPosn = 0;
+                bufferLength = fillBuffer(in, buffer, ambiguousByteCount > 0);
+                if (bufferLength <= 0) {
+                    if (ambiguousByteCount > 0) {
+                        str.append(recordDelimiterBytes, 0, ambiguousByteCount);
+                        bytesConsumed += ambiguousByteCount;
+                    }
+                    break; // EOF
+                }
+            }
+            for (; bufferPosn < bufferLength; ++bufferPosn) {
+                if (buffer[bufferPosn] == recordDelimiterBytes[delPosn]) {
+                    delPosn++;
+                    if (delPosn >= recordDelimiterBytes.length) {
+                        bufferPosn++;
+                        break;
+                    }
+                }
+                else if (delPosn != 0) {
+                    bufferPosn -= delPosn;
+                    if (bufferPosn < -1) {
+                        bufferPosn = -1;
+                    }
+                    delPosn = 0;
+                }
+            }
+            int readLength = bufferPosn - startPosn;
+            bytesConsumed += readLength;
+            int appendLength = readLength - delPosn;
+            if (appendLength > maxLineLength - txtLength) {
+                appendLength = maxLineLength - txtLength;
+            }
+            bytesConsumed += ambiguousByteCount;
+            if (appendLength >= 0 && ambiguousByteCount > 0) {
+                //appending the ambiguous characters (refer case 2.2)
+                str.append(recordDelimiterBytes, 0, ambiguousByteCount);
+                ambiguousByteCount = 0;
+                // since it is now certain that the split did not split a delimiter we
+                // should not read the next record: clear the flag otherwise duplicate
+                // records could be generated
+                unsetNeedAdditionalRecordAfterSplit();
+            }
+            if (appendLength > 0) {
+                str.append(buffer, startPosn, appendLength);
+                txtLength += appendLength;
+            }
+            if (bufferPosn >= bufferLength) {
+                if (delPosn > 0 && delPosn < recordDelimiterBytes.length) {
+                    ambiguousByteCount = delPosn;
+                    bytesConsumed -= ambiguousByteCount; //to be consumed in next
+                }
+            }
+        }
+        while (delPosn < recordDelimiterBytes.length
+                && bytesConsumed < maxBytesToConsume);
+        if (bytesConsumed > Integer.MAX_VALUE) {
+            throw new IOException("Too many bytes before delimiter: " + bytesConsumed);
+        }
+        return (int) bytesConsumed;
+    }
+
+    /**
+     * Read from the InputStream into the given Text.
+     * @param str the object to store the given line
+     * @param maxLineLength the maximum number of bytes to store into str.
+     * @return the number of bytes read including the newline
+     * @throws IOException if the underlying stream throws
+     */
+    public int readLine(Text str, int maxLineLength)
+            throws IOException
+    {
+        return readLine(str, maxLineLength, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Read from the InputStream into the given Text.
+     * @param str the object to store the given line
+     * @return the number of bytes read including the newline
+     * @throws IOException if the underlying stream throws
+     */
+    public int readLine(Text str)
+            throws IOException
+    {
+        return readLine(str, Integer.MAX_VALUE, Integer.MAX_VALUE);
+    }
+
+    protected int getBufferPosn()
+    {
+        return bufferPosn;
+    }
+
+    protected int getBufferSize()
+    {
+        return bufferSize;
+    }
+
+    protected void unsetNeedAdditionalRecordAfterSplit()
+    {
+        // needed for custom multi byte line delimiters only
+        // see MAPREDUCE-6549 for details
+    }
+}

--- a/src/main/java/org/apache/hadoop/util/LineReader.java
+++ b/src/main/java/org/apache/hadoop/util/LineReader.java
@@ -258,6 +258,10 @@ public class LineReader
             int appendLength = readLength - newlineLength;
             if (appendLength > maxLineLength - txtLength) {
                 appendLength = maxLineLength - txtLength;
+                if (appendLength > 0) {
+                    // We want to fail the read when the line length is over the limit.
+                    throw new IOException("Too many bytes before newline: " + maxLineLength);
+                }
             }
             if (appendLength > 0) {
                 int newTxtLength = txtLength + appendLength;
@@ -272,7 +276,10 @@ public class LineReader
         }
         while (newlineLength == 0 && bytesConsumed < maxBytesToConsume);
 
-        if (bytesConsumed > Integer.MAX_VALUE) {
+        if (newlineLength == 0 && bytesConsumed >= maxBytesToConsume) {
+            // It is possible that bytesConsumed is over the maxBytesToConsume but we
+            // didn't append anything to str.bytes. If we have consumed over maxBytesToConsume
+            // bytes but still haven't seen a line terminator, we will fail the read.
             throw new IOException("Too many bytes before newline: " + bytesConsumed);
         }
         return (int) bytesConsumed;
@@ -359,6 +366,10 @@ public class LineReader
             int appendLength = readLength - delPosn;
             if (appendLength > maxLineLength - txtLength) {
                 appendLength = maxLineLength - txtLength;
+                if (appendLength > 0) {
+                    // We want to fail the read when the line length is over the limit.
+                    throw new IOException("Too many bytes before delimiter: " + maxLineLength);
+                }
             }
             bytesConsumed += ambiguousByteCount;
             if (appendLength >= 0 && ambiguousByteCount > 0) {
@@ -389,7 +400,11 @@ public class LineReader
         }
         while (delPosn < recordDelimiterBytes.length
                 && bytesConsumed < maxBytesToConsume);
-        if (bytesConsumed > Integer.MAX_VALUE) {
+        if (delPosn < recordDelimiterBytes.length
+                && bytesConsumed >= maxBytesToConsume) {
+            // It is possible that bytesConsumed is over the maxBytesToConsume but we
+            // didn't append anything to str.bytes. If we have consumed over maxBytesToConsume
+            // bytes but still haven't seen a line terminator, we will fail the read.
             throw new IOException("Too many bytes before delimiter: " + bytesConsumed);
         }
         return (int) bytesConsumed;

--- a/src/test/java/com/facebook/presto/hadoop/TestLineReader.java
+++ b/src/test/java/com/facebook/presto/hadoop/TestLineReader.java
@@ -1,0 +1,151 @@
+package com.facebook.presto.hadoop;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.util.LineReader;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestLineReader
+{
+    @Test
+    public void testDefaultReaderZeroBytes()
+            throws IOException
+    {
+        byte[] input = "Hello world! Goodbye world!\n".getBytes(UTF_8);
+        InputStream in = new ByteArrayInputStream(input);
+        // Set the LineReader internal read buffer size 4 bytes
+        LineReader reader = new LineReader(in, 4);
+        Text str = new Text();
+        reader.readLine(str, 0, 30);
+        // There should not be any bytes read into str because the maxLineLength is 0
+        assertEquals(str, new Text());
+    }
+
+    @Test
+    public void testDefaultReaderNonZeroBytes()
+            throws IOException
+    {
+        byte[] input = "Hello world! Goodbye world!\n".getBytes(UTF_8);
+        InputStream in = new ByteArrayInputStream(input);
+        // Set the LineReader internal read buffer size 4 bytes
+        LineReader reader = new LineReader(in, 4);
+        Text str = new Text();
+        reader.readLine(str, 30, 30);
+        // The LineReader does not store the new line character into str,
+        // so we need to compare just the first 27 characters.
+        assertEquals(str, new Text("Hello world! Goodbye world!".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void testCustomReaderZeroBytes()
+            throws IOException
+    {
+        byte[] input = "Hello world! Goodbye world!\n".getBytes(UTF_8);
+        byte[] delimiter = "!".getBytes(UTF_8);
+        InputStream in = new ByteArrayInputStream(input);
+        // Set the LineReader internal read buffer size 4 bytes
+        LineReader reader = new LineReader(in, 4, delimiter);
+        Text str = new Text();
+        reader.readLine(str, 0, 30);
+        // There should not be any bytes read into str because the maxLineLength is 0
+        assertEquals(str, new Text());
+    }
+
+    @Test
+    public void testCustomReaderNonZeroBytes()
+            throws IOException
+    {
+        byte[] input = "Hello world! Goodbye world!\n".getBytes(UTF_8);
+        byte[] delimiter = "!".getBytes(UTF_8);
+        InputStream in = new ByteArrayInputStream(input);
+        // Set the LineReader internal read buffer size 4 bytes
+        LineReader reader = new LineReader(in, 4, delimiter);
+        Text str = new Text();
+        reader.readLine(str, 30, 30);
+        // The first 11 bytes of input should be read into str because the 12th character is the delimiter
+        assertEquals(str, new Text("Hello world".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void testDefaultReaderMaxBytesConsumed()
+    {
+        byte[] input = "Hello world! Goodbye world!\n".getBytes(UTF_8);
+        InputStream in = new ByteArrayInputStream(input);
+        // Set the LineReader internal read buffer size 4 bytes
+        LineReader reader = new LineReader(in, 4);
+        Text str = new Text();
+        try {
+            // The read should fail because the line length is greater than the maxBytesToConsume
+            reader.readLine(str, 0, 10);
+            fail("Expected IOException");
+        }
+        catch (IOException e) {
+            // It should be 3 reads of 4 bytes each, so the final bytesConsumed is 12
+            assertEquals(e.getMessage(), "Too many bytes before newline: 12");
+        }
+    }
+
+    @Test
+    public void testDefaultReaderMaxLineLength()
+    {
+        byte[] input = "Hello world! Goodbye world!\n".getBytes(UTF_8);
+        InputStream in = new ByteArrayInputStream(input);
+        // Set the LineReader internal read buffer size 4 bytes
+        LineReader reader = new LineReader(in, 4);
+        Text str = new Text();
+        try {
+            // The read should fail because the line length is greater than the maxLineLength
+            reader.readLine(str, 10, 100);
+            fail("Expected IOException");
+        }
+        catch (IOException e) {
+            assertEquals(e.getMessage(), "Too many bytes before newline: 10");
+        }
+    }
+
+    @Test
+    public void testCustomReaderMaxBytesConsumed()
+    {
+        byte[] input = "Hello world! Goodbye world!\n".getBytes(UTF_8);
+        byte[] delimiter = "!".getBytes(UTF_8);
+        InputStream in = new ByteArrayInputStream(input);
+        // Set the LineReader internal read buffer size 4 bytes
+        LineReader reader = new LineReader(in, 4, delimiter);
+        Text str = new Text();
+        try {
+            // The read should fail because the line length is greater than the maxBytesToConsume
+            reader.readLine(str, 0, 5);
+            fail("Expected IOException");
+        }
+        catch (IOException e) {
+            // It should be 2 reads of 4 bytes each, so the final bytesConsumed is 8
+            assertEquals(e.getMessage(), "Too many bytes before delimiter: 8");
+        }
+    }
+
+    @Test
+    public void testCustomReaderMaxLineLength()
+    {
+        byte[] input = "Hello world! Goodbye world!\n".getBytes(UTF_8);
+        byte[] delimiter = "!".getBytes(UTF_8);
+        InputStream in = new ByteArrayInputStream(input);
+        // Set the LineReader internal read buffer size 4 bytes
+        LineReader reader = new LineReader(in, 4, delimiter);
+        Text str = new Text();
+        try {
+            // The read should fail because the line length is greater than the maxLineLength
+            reader.readLine(str, 10, 100);
+            fail("Expected IOException");
+        }
+        catch (IOException e) {
+            assertEquals(e.getMessage(), "Too many bytes before delimiter: 10");
+        }
+    }
+}


### PR DESCRIPTION
Throw IOException when the text line is too big and
1) The capacity of the Text object is over the VM limit for the array size;
2) The bytes to store into the Text object is over the maxLineLength limit;
3) The consumed bytes is over the maxBytesToConsume.

Case 1) would cause OOM, and the fix (the same as the second commit in this PR)
was submitted as the following PR to Apache Hadoop:
https://github.com/apache/hadoop/pull/414

The fix for case 2) and 3) was behavior change so that when the line is over the configured
maxLineLength limit (suppose it's less than the VM array size limit), the LineReader 
throws IOException so that the query would fail loudly. The original LineReader behavior 
was to silently discard the content for a line after the maxLineLength limit.
