### PR TITLE
Remove the legacy hdfs configuration

### DIFF
--- a/src/main/resources/core-site.xml
+++ b/src/main/resources/core-site.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-<configuration>
-    <property>
-        <name>dfs.client.use.legacy.blockreader</name>
-        <value>true</value>
-    </property>
-</configuration>


### PR DESCRIPTION
Remove the legacy `dfs.client.use.legacy.blockreader` configuraiton

The legacy RemoteBlockReader has been deprecated for a long time,
remove this configuration in order to keep it false in default.