### PR TITLE
Update PRESTO_S3_IAM_ROLE config key name in PrestoFileSystemCache

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
+++ b/src/main/java/org/apache/hadoop/fs/PrestoFileSystemCache.java
@@ -45,7 +45,7 @@ public class PrestoFileSystemCache
 {
     public static final Log log = LogFactory.getLog(PrestoFileSystemCache.class);
     public static final String PRESTO_GCS_OAUTH_ACCESS_TOKEN_KEY = "presto.gcs.oauth-access-token";
-    public static final String PRESTO_S3_IAM_ROLE = "presto.s3.iam-role";
+    public static final String PRESTO_S3_IAM_ROLE = "presto.hive.s3.iam-role";
     public static final String PRESTO_S3_ACCESS_KEY = "presto.s3.access-key";
 
     private final AtomicLong unique = new AtomicLong();


### PR DESCRIPTION
Updated the Presto S3 IAM Role configuration key name to the same that is being used in Presto now. 