### PR TITLE
Fix FileSystem closed after pr 23

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/FileSystemCleaner.java
+++ b/src/main/java/org/apache/hadoop/fs/FileSystemCleaner.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *  Manage FileSystemHolders that removed from PrestoFileSystemCache, and close them after PRESTO_HDFS_EXPIRED_FS_DELAY_CLOSE_TIME.
+ *  To avoid Filesystem closed Exception caused by closing FileSystem in use.
+ */
+public class FileSystemCleaner
+{
+    public static final Log log = LogFactory.getLog(FileSystemCleaner.class);
+    public static final String PRESTO_HDFS_EXPIRED_FS_DELAY_CLOSE_TIME = "presto.hdfs.expired.fs.delay.close.time";
+    public static final String PRESTO_HDFS_EXPIRED_FS_CHECK_INTERVAL = "presto.hdfs.expired.fs.check.interval";
+    public static final long DEFAULT_PRESTO_HDFS_FS_CACHE_DELAY_CLOSE_TIME = 5 * 60 * 1000; // five minutes
+    public static final long DEFAULT_PRESTO_HDFS_EXPIRED_FS_CHECK_INTERVAL = 60 * 1000;  // one minute
+
+    private static final FileSystemCleaner manager = new FileSystemCleaner();
+    private static final List<PrestoFileSystemCache.FileSystemHolder> fileSystemHolderList = new LinkedList<>();
+
+    public FileSystemCleaner()
+    {
+        Thread fileSystemCleanerTask = new FileSystemCleanerTask();
+        fileSystemCleanerTask.setDaemon(true);
+        fileSystemCleanerTask.setName("FileSystemCleanerTask");
+        fileSystemCleanerTask.start();
+    }
+
+    public static FileSystemCleaner getInstance()
+    {
+        return manager;
+    }
+
+    public void addExpiredFileSystem(PrestoFileSystemCache.FileSystemHolder fileSystemHolder)
+    {
+        fileSystemHolder.setExpireTimestamp(System.currentTimeMillis());
+        fileSystemHolderList.add(fileSystemHolder);
+    }
+
+    private static class FileSystemCleanerTask
+            extends Thread
+    {
+        @Override
+        public void run()
+        {
+            while (true) {
+                for (PrestoFileSystemCache.FileSystemHolder holder : fileSystemHolderList) {
+                    long delayCloseTime = holder.getFileSystem().getConf().getLong(PRESTO_HDFS_EXPIRED_FS_DELAY_CLOSE_TIME,
+                            DEFAULT_PRESTO_HDFS_FS_CACHE_DELAY_CLOSE_TIME);
+                    if (System.currentTimeMillis() - holder.getExpireTimestamp() >= delayCloseTime) {
+                        try {
+                            log.info(String.format("Closing expired FileSystem{expireTimestamp: %s, delayCloseTime: %s ms}",
+                                    holder.getExpireTimestamp(), delayCloseTime));
+                            holder.getFileSystem().close();
+                            fileSystemHolderList.remove(holder);
+                        }
+                        catch (IOException e) {
+                            log.error("Close expired file system fail ", e);
+                        }
+                    }
+                    else {
+                        break;
+                    }
+                }
+
+                try {
+                    Thread.sleep(DEFAULT_PRESTO_HDFS_EXPIRED_FS_CHECK_INTERVAL);
+                }
+                catch (InterruptedException e) {
+                    log.error(e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Some queries fail  cause by FileSystem closed exception when I used jmeter for load test.
My Environment：
  presto ： 0.265.1
  presto-hadoop-apache2: 2.7.4-9
  hadoop (with rbf and keberos) :  3.2.1
  hive: 1.2.1
  jmeter(use 100 threads to run ):   5.3

Query Error Infomation：
![image](https://user-images.githubusercontent.com/4393025/147235455-bed7b1b6-26ad-4ca9-8948-d19570f41d53.png)

I suspect this problem is caused by the privatecredentials of the PrestoFileSystemCache class. So I add some logs in fileSystemRefresh code block of PrestoFileSystemCache.getInternal()
![image](https://user-images.githubusercontent.com/4393025/147238716-70bd97a2-040f-47dd-a7ba-a55b41318ad3.png)

At the same time, add a log before close filesystem.
![image](https://user-images.githubusercontent.com/4393025/147237294-326478a9-39a3-401b-819e-b9ad1781b43b.png)

Run jmeter script again, I get these logs
![image](https://user-images.githubusercontent.com/4393025/147237480-6dc3ae3a-e4db-4bc8-8416-ade58220f2cd.png)

As can be seen from the above logs. A total of 3 FileSystem created in one second,  include two time FileSystemRefresh. Finally, the two filesystems are shut down in the following one second. This leads to FileSystem closed exception. One second is so short, the filesystem that is closed is using by queries when it is closed. 

Multiple filesystem refreshes occur because the newly acquired private credentials are always more than those in the cached filesystemholder at the beginning. Therefore, when determining whether to need filesystem refresh, we should replace equals() with containsAll(), like this
![image](https://user-images.githubusercontent.com/4393025/147239702-dd25a9e9-9b18-4e8a-8ea1-830271dc984c.png)

Run jmeter script again, just a filesystem is created after equals() with containsAll(). There is no any filesystem closed exception. But I think the problem has not been completely solved. Because FinalizerService make the time to close the filesystem uncontrollable. The FileSystem may be closed immediately cause by jvm gc when Kerberos ticket has expired and re-login happened, then FileSystem closed exception will  occur again. 

So, I think that the FileSystem should be delay closed after a configuratable time. I add a config presto.hdfs.expired.fs.delay.close.time to crontrol how long it takes to close the FileSystem  after FileSystem is removed from PrestoFileSystemCache.map. the default value is 300000 ms(5 minutes).  The log show 2 of 3 FileSystem are closed afiter 5 minutes.
![image](https://user-images.githubusercontent.com/4393025/147242620-d6a1f995-29de-4e57-bdd8-5a0ccf47962b.png)


