### PR TITLE
Revert "Remove the legacy hdfs configuration"

### DIFF
--- a/src/main/resources/core-site.xml
+++ b/src/main/resources/core-site.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<configuration>
+    <property>
+        <name>dfs.client.use.legacy.blockreader</name>
+        <value>true</value>
+    </property>
+</configuration>


### PR DESCRIPTION
This reverts commit 70728f4d47d8bc63b26d867bdd7c20a9a8fa4054.

This change can only be added when using Hadoop 3.x. To unblock the development efforts dependent on the shaded hadoop library, this commit is being reverted. It will be re-introduced once we upgrade Presto to use Hadoop 3.2.x.