### PR TITLE
Upgrade avro to 1.11.3 due CVE-2023-39410

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.targetJdk>1.7</project.build.targetJdk>
         <shadeBase>com.facebook.presto.hadoop.\$internal</shadeBase>
+        <dep.avro.version>1.11.3</dep.avro.version>
         <dep.slf4j.version>1.7.13</dep.slf4j.version>
         <dep.hadoop.version>2.7.4</dep.hadoop.version>
 
@@ -53,6 +54,16 @@
 
         <air.javadoc.lint>-missing</air.javadoc.lint>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>${dep.avro.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -455,8 +466,8 @@
                                     <shadedPattern>${shadeBase}.com.google.gson</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>com.fasterxml.jackson.core</pattern>
-                                    <shadedPattern>${shadeBase}.com.fasterxml.jackson.core</shadedPattern>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>${shadeBase}.com.fasterxml.jackson</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.codehaus.jackson</pattern>


### PR DESCRIPTION
Upgrade avro to 1.11.3 to solve https://github.com/advisories/GHSA-rhrv-645h-fjfh.

We need this PR and https://github.com/prestodb/presto-hive-apache/pull/64 to fix https://github.com/advisories/GHSA-rhrv-645h-fjfh in Presto.