### PR TITLE
Fix NoClassDefFoundError while inserting into a table in a kerberos enabled Environment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,10 +260,6 @@
                     <artifactId>reload4j</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk18on</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>io.dropwizard.metrics</groupId>
                     <artifactId>metrics-core</artifactId>
                 </exclusion>
@@ -489,7 +485,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -600,6 +596,10 @@
                                 <relocation>
                                     <pattern>com.google.thirdparty.publicsuffix</pattern>
                                     <shadedPattern>${shadeBase}.com.google.thirdparty.publicsuffix</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.bouncycastle</pattern>
+                                    <shadedPattern>${shadeBase}.org.bouncycastle</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>


### PR DESCRIPTION
### Description

- This PR fixes NoClassDefFoundError while inserting into a table in a kerberos enabled Environment

       `java.lang.NoClassDefFoundError: org/bouncycastle/jce/provider/BouncyCastleProvider`

- This PR also upgrades the` maven-shade-plugin` from version 3.2.1 to 3.5.0 to resolve a build failure caused by    unsupported class file version errors when shading newer JARs ( with Java 15+ classes).
    
     `
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.2.1:shade (default) on project hadoop-apache2: Error creating shaded jar: Problem shading JAR /Users/nishithakbhaskaran/.m2/repository/org/bouncycastle/bcprov-jdk18on/1.78.1/bcprov-jdk18on-1.78.1.jar entry META-INF/versions/15/org/bouncycastle/jcajce/provider/asymmetric/edec/BC15EdDSAPrivateKey.class: java.lang.IllegalArgumentException: Unsupported class file major version 59 -> [Help 1]`


